### PR TITLE
Adaptation of Wildcard Domain ssl certificates

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker-compose up -d
 ### Generate certificates for the first time
 ```sh
 docker-compose exec app sh
-./namesilo-certbot.sh --email me@blue.planet -d "example.com"
+./namesilo-certbot.sh --email me@blue.planet -d "example.com" -d "*.example.com"
 ```
 This command will generate certificate key files under `letsencrypt` folder (specified in the docker compose volume section). The script will take 60 minutes to finish execution (due to Namesilo's DNS propagation taking approximately 60 minutes at the time of writing this. Feel free to adjust the waiting minutes appropriately in `config.py`).
 


### PR DESCRIPTION
I thought I just had to write the domain name once, like `-d "example.com"`, and after a successful deployment it kept reporting the error . 

```text
curl:(60)SSL: no alternative certificate subject namematches target host name'aa.my-example.com More details here: https://curl.se/docs/sslcerts.html

curl failed to verify the legitimacy of the server and therefore could notestablish a secure connection to it. To learn more about this situation and
how to fix it,please visit the web page mentioned above.
```

Adding the parameter `-d *.example.com` and redeploying works.